### PR TITLE
add optional program id to shank generator

### DIFF
--- a/src/generators/shank.ts
+++ b/src/generators/shank.ts
@@ -12,6 +12,7 @@ export default async function generate(
     binaryInstallDir,
     programDir,
     programName,
+    programId,
     binaryExtraArgs,
   } = config;
   const binaryArgs = [
@@ -20,6 +21,7 @@ export default async function generate(
     idlDir,
     '--crate-root',
     programDir,
+    ...(programId ? ['--program-id', `${programId}`] : []),
     ...(idlName ? ['--out-filename', `${idlName}.json`] : []),
     ...(binaryExtraArgs ?? []),
   ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type AnchorGeneratorOptions = BaseGeneratorOptions & {
 
 export type ShankGeneratorOptions = BaseGeneratorOptions & {
   generator: 'shank';
+  programId?: string;
 };
 
 export type GeneratorOptions = AnchorGeneratorOptions | ShankGeneratorOptions;


### PR DESCRIPTION
I ran into the following error when using declare_id more than once with the shank generator:

`Error: Found more than one program id candidate: You should either have exactly one `declare_id!` in your code or override the program id via -p`

This PR adds an optional programId to the shank generator. 